### PR TITLE
Added missing dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Tested on Ubuntu 18.04 (x86-64)
 Dependencies
 
 ```
-sudo apt install libmad-ocaml-dev libtwin-dev
+sudo apt install libmad-ocaml-dev libtwin-dev libcairo2-dev libboost-dev
 ```
 
 How to build


### PR DESCRIPTION
On my freshly installed Ubuntu, Cairo and Boost were missing so I had to install them.